### PR TITLE
add: Se añade endpoint /tasas_representativas

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,5 +1,5 @@
 from fastapi import FastAPI
-from routers import listas_gi, fichas_tecnicas, ordenes_compra, check_health, existencias_siesa
+from routers import listas_gi, fichas_tecnicas, ordenes_compra, check_health, existencias_siesa, trm
 from dotenv import load_dotenv
 import os
 
@@ -28,6 +28,7 @@ app.include_router(listas_gi.router)
 app.include_router(fichas_tecnicas.router)
 app.include_router(check_health.router)
 app.include_router(existencias_siesa.router)
+app.include_router(trm.router)
 
 if __name__ == "__main__":
     import uvicorn

--- a/routers/trm.py
+++ b/routers/trm.py
@@ -1,0 +1,37 @@
+from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+from fastapi import HTTPException
+from db.connection import get_connection_siesa
+from utils.fetch_all import fetch_all
+
+router = APIRouter(
+    tags= ["Tasas representativas del mercado"]
+)
+
+@router.get("/tasas_representativas", summary="Consulta las tasas representativas para USD ($) y EUR")
+def get_tasas_representativas(dias_atras: int):
+    try:
+        conn = get_connection_siesa()
+        cursor = conn.cursor()
+        cursor.execute("""
+SELECT
+    [F018_ID_MONEDA] AS 'moneda'
+    ,[F018_TASA] AS 'tasa_representativa'
+    ,CAST([F018_TS] AS DATE) AS 'fecha'
+FROM
+    [UnoEE_Gelco_Real].[dbo].[T018_MM_TASAS_CAMBIO]
+WHERE
+    (TRY_CAST(F018_TS AS DATE) >= TRY_CAST(DATEADD(DAY, -?, GETDATE()) AS DATE))
+    AND F018_ID_MONEDA IN ('USD', 'EUR')
+    AND F018_ID_CIA = 1
+    ORDER BY [F018_ID_MONEDA], [F018_TS]
+""", (dias_atras,))
+        data = fetch_all(cursor)
+        return data
+    except Exception as e:
+        raise HTTPException(status_code=500, detail={'message': 'No se pudieron obtener las tasas representativas'})
+    finally:
+        if cursor is not None:
+            cursor.close()
+        if conn is not None:
+            conn.close()


### PR DESCRIPTION
- Obtenemos directamente de la base de datos de SIESA las tasas de cambio para USD y EUR
- Parametrizable con ?dias_atras=int