### PR TITLE
- add: Se añade paths-ignore a .github/deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,13 @@ name: Deploy API GELCO
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.dockerignore'
+      - '.docker-compose.yml'
+      - 'pytest.ini'
+      - 'requirements.txt'
 
 jobs:
   deploy:


### PR DESCRIPTION
Esto con el fin de evitar que commits que afectan archivos individuales bajen la API en producción.
Solo dispararemos la action cuando se afecte código relevante.